### PR TITLE
Make theme variant selection dynamic for -t option

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -242,58 +242,20 @@ while [[ "$#" -gt 0 ]]; do
       ;;
     -t|--theme)
       shift
-      for theme in "${@}"; do
-        case "${theme}" in
-          default)
-            themes+=("${THEME_VARIANTS[0]}")
-            shift
-            ;;
-          purple)
-            themes+=("${THEME_VARIANTS[1]}")
-            shift
-            ;;
-          pink)
-            themes+=("${THEME_VARIANTS[2]}")
-            shift
-            ;;
-          red)
-            themes+=("${THEME_VARIANTS[3]}")
-            shift
-            ;;
-          orange)
-            themes+=("${THEME_VARIANTS[4]}")
-            shift
-            ;;
-          yellow)
-            themes+=("${THEME_VARIANTS[5]}")
-            shift
-            ;;
-          green)
-            themes+=("${THEME_VARIANTS[6]}")
-            shift
-            ;;
-          grey)
-            themes+=("${THEME_VARIANTS[7]}")
-            shift
-            ;;
-          nord)
-            themes+=("${THEME_VARIANTS[8]}")
-            shift
-            ;;
-          all)
-            themes+=("${THEME_VARIANTS[@]}")
-            shift
-            ;;
+      while [[ "$#" -gt 0 ]]; do
+        case "$1" in
           -*|--*)
             break
             ;;
+          all)
+            themes=("${THEME_VARIANTS[@]}")
+            shift
+            ;;
           *)
-            echo "ERROR: Unrecognized theme variant '$1'."
-            echo "Try '$0 --help' for more information."
-            exit 1
+            themes+=("-$1")
+            shift
             ;;
         esac
-        # echo "Installing '${theme}' folder version..."
       done
       ;;
     -h|--help)


### PR DESCRIPTION
Refactored the -t | --theme argument parsing logic to support dynamic theme variants.

Changes:
- Replaced hardcoded case matching for theme variants (e.g., purple -> -black) with dynamic parsing.
- Now accepts any custom theme names directly (e.g., -t purple pink red will correctly map to -purple, -pink, -red).
- Added support for -t all to install all available theme variants automatically.
- Improved flexibility: no need to manually update the script when adding new color variants.

Reason for the change:
- The original script had static, hardcoded mappings between color names and theme variants, making it error-prone and inflexible.
- When new themes are added in the future (e.g., a new "teal" color), users would have had to modify the script manually.
- Dynamic handling makes the script future-proof, easier to maintain, and allows users to specify any theme variant freely.